### PR TITLE
Add permission required by 'test user' to get network

### DIFF
--- a/iam_test_user.tf
+++ b/iam_test_user.tf
@@ -74,6 +74,7 @@ resource "google_project_iam_custom_role" "network_project_test_user_role" {
     "resourcemanager.projects.get",
     "compute.subnetworks.get",
     "compute.subnetworks.getIamPolicy",
+    "compute.networks.get",
     "compute.networks.getRegionEffectiveFirewalls",
     "resourcemanager.projects.getIamPolicy",
     "iam.roles.get",


### PR DESCRIPTION
Used when running `rpk cloud byoc apply` for validation purposes, to ensure everything is configured in a way that will set the cluster creation up for success.