### PR TITLE
Add more flexibility for which resources are created by the module

### DIFF
--- a/firewall.tf
+++ b/firewall.tf
@@ -1,7 +1,7 @@
 resource "google_compute_firewall" "redpanda_ingress_allow_redpanda" {
   name        = "redpanda-ingress${local.postfix}"
   description = "Allow access to Redpanda cluster"
-  network     = google_compute_network.redpanda.name
+  network     = data.google_compute_network.redpanda.name
   project     = var.network_project_id
 
   allow {
@@ -27,7 +27,7 @@ resource "google_compute_firewall" "redpanda_ingress_allow_psc" {
   count       = var.enable_private_link ? 1 : 0
   name        = "redpanda-ingress${local.postfix}-psc"
   description = "Allow access to Redpanda cluster"
-  network     = google_compute_network.redpanda.name
+  network     = data.google_compute_network.redpanda.name
   project     = var.network_project_id
 
   allow {
@@ -60,7 +60,7 @@ resource "google_compute_firewall" "master_webhooks" {
   name        = "gke-rp-cluster-webhooks${local.postfix}"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = var.network_project_id
-  network     = google_compute_network.redpanda.name
+  network     = data.google_compute_network.redpanda.name
   priority    = 1000
   direction   = "INGRESS"
 

--- a/iam_agent.tf
+++ b/iam_agent.tf
@@ -167,7 +167,7 @@ resource "google_storage_bucket_iam_member" "redpanda_agent_storage_object_admin
 }
 
 resource "google_project_iam_member" "redpanda_agent_shared_vpc_permissions" {
-  count   = local.using_shared_vpc ? 1 : 0
+  count   = local.is_shared_vpc ? 1 : 0
   project = var.network_project_id
   role    = google_project_iam_custom_role.shared_vpc_redpanda_agent[0].id
   member  = "serviceAccount:${google_service_account.redpanda_agent.email}"
@@ -177,7 +177,7 @@ resource "google_project_iam_member" "redpanda_agent_shared_vpc_permissions" {
 }
 
 resource "google_project_iam_custom_role" "shared_vpc_redpanda_agent" {
-  count       = local.using_shared_vpc ? 1 : 0
+  count       = local.is_shared_vpc ? 1 : 0
   role_id     = replace("redpanda_agent_role_network${local.postfix}", "-", "_")
   title       = "Redpanda Agent Role"
   description = "A role granting the redpanda agent permissions to view network resources in the project of the vpc."

--- a/iam_test_user.tf
+++ b/iam_test_user.tf
@@ -63,7 +63,7 @@ resource "google_project_iam_member" "test_user_role_binding" {
 }
 
 resource "google_project_iam_custom_role" "network_project_test_user_role" {
-  count       = local.using_shared_vpc ? 1 : 0
+  count       = local.is_shared_vpc ? 1 : 0
   role_id     = replace("byovpc_test_user_role${local.postfix}", "-", "_")
   title       = "BYOVPC Test User Role"
   description = <<EOT
@@ -84,7 +84,7 @@ resource "google_project_iam_custom_role" "network_project_test_user_role" {
 }
 
 resource "google_project_iam_member" "test_user_shared_vpc_permissions" {
-  count   = local.using_shared_vpc && var.create_test_user ? 1 : 0
+  count   = local.is_shared_vpc && var.create_test_user ? 1 : 0
   project = var.network_project_id
   role    = google_project_iam_custom_role.network_project_test_user_role[0].id
   member  = "serviceAccount:${google_service_account.test_user_account[0].email}"

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  using_shared_vpc = (var.service_project_id != var.network_project_id)
-  postfix          = var.unique_identifier != "" ? "-${var.unique_identifier}" : ""
+  is_shared_vpc = (var.service_project_id != var.network_project_id)
+  postfix       = var.unique_identifier != "" ? "-${var.unique_identifier}" : ""
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@ output "management_bucket_name" {
 }
 
 output "network_name" {
-  value = google_compute_network.redpanda.name
+  value = data.google_compute_network.redpanda.name
 }
 
 output "network_project_id" {
@@ -51,15 +51,15 @@ output "k8s_master_ipv4_range" {
 }
 
 output "subnet_name" {
-  value = google_compute_subnetwork.redpanda.name
+  value = data.google_compute_subnetwork.redpanda.name
 }
 
 output "secondary_ipv4_range_pods_name" {
-  value = google_compute_subnetwork.redpanda.secondary_ip_range.0.range_name
+  value = var.secondary_ipv4_range_pods_name
 }
 
 output "secondary_ipv4_range_services_name" {
-  value = google_compute_subnetwork.redpanda.secondary_ip_range.1.range_name
+  value = var.secondary_ipv4_range_services_name
 }
 
 output "tiered_storage_bucket_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -118,3 +118,39 @@ variable "psc_nat_subnet_ipv4_range" {
   The IPv4 CIDR range of the PSC NAT subnet
   HELP
 }
+
+variable "vpc_name" {
+  type        = string
+  default     = ""
+  description = <<-HELP
+  The name of the VPC network if created outside of this module
+  HELP
+}
+
+variable "subnet_name" {
+  type        = string
+  default     = ""
+  description = <<-HELP
+  The name of the subnet if created outside of this module. If vpc_name is provided, this value is required.
+  HELP
+  validation {
+    condition     = var.vpc_name != "" && var.subnet_name != ""
+    error_message = "If vpc_name is provided, subnet_name is required"
+  }
+}
+
+variable "secondary_ipv4_range_pods_name" {
+  type        = string
+  default     = "redpanda-pods"
+  description = <<-HELP
+    The name of the secondary IP range for pods
+    HELP
+}
+
+variable "secondary_ipv4_range_services_name" {
+  type        = string
+  default     = "redpanda-services"
+  description = <<-HELP
+    The name of the secondary IP range for services
+    HELP
+}

--- a/variables.tf
+++ b/variables.tf
@@ -154,3 +154,27 @@ variable "secondary_ipv4_range_services_name" {
     The name of the secondary IP range for services
     HELP
 }
+
+variable "subnetwork_ip_cidr_range" {
+  type        = string
+  default     = "10.0.0.0/24"
+  description = <<-HELP
+    The IP CIDR range of the subnetwork
+    HELP
+}
+
+variable "subnetwork_pods_secondary_ip_range" {
+  type        = string
+  default     = "10.0.8.0/21"
+  description = <<-HELP
+    The IP CIDR range of the subnetwork pods secondary IP range
+    HELP
+}
+
+variable "subnetwork_services_secondary_ip_range" {
+  type        = string
+  default     = "10.0.1.0/24"
+  description = <<-HELP
+    The IP CIDR range of the subnetwork services secondary IP range
+    HELP
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -9,7 +9,13 @@ resource "google_compute_shared_vpc_service_project" "service_project" {
   service_project = var.service_project_id
 }
 
+locals {
+  create_vpc        = var.vpc_name == "" ? true : false
+  create_subnetwork = local.create_vpc
+}
+
 resource "google_compute_network" "redpanda" {
+  count                           = local.create_vpc ? 1 : 0
   name                            = "redpanda-network${local.postfix}"
   auto_create_subnetworks         = false
   delete_default_routes_on_create = false
@@ -18,33 +24,48 @@ resource "google_compute_network" "redpanda" {
   project                         = var.network_project_id
 }
 
+data "google_compute_network" "redpanda" {
+  name    = local.create_vpc ? google_compute_network.redpanda[0].name : var.vpc_name
+  project = var.network_project_id
+  depends_on = [
+    google_compute_network.redpanda
+  ]
+}
+
 resource "google_compute_subnetwork" "redpanda" {
+  count                    = local.create_subnetwork ? 1 : 0
   name                     = "redpanda-subnetwork${local.postfix}"
-  network                  = google_compute_network.redpanda.id
+  network                  = data.google_compute_network.redpanda.id
   region                   = var.region
   ip_cidr_range            = "10.0.0.0/24"
   private_ip_google_access = true
   stack_type               = "IPV4_ONLY"
   secondary_ip_range {
     ip_cidr_range = "10.0.8.0/21"
-    range_name    = "redpanda-pods"
+    range_name    = var.secondary_ipv4_range_pods_name
   }
   secondary_ip_range {
     ip_cidr_range = "10.0.1.0/24"
-    range_name    = "redpanda-services"
+    range_name    = var.secondary_ipv4_range_services_name
   }
   depends_on = [
-    google_compute_network.redpanda
+    data.google_compute_network.redpanda
   ]
+  project = var.network_project_id
+}
+
+data "google_compute_subnetwork" "redpanda" {
+  name    = local.create_subnetwork ? google_compute_subnetwork.redpanda[0].name : var.subnet_name
+  region  = var.region
   project = var.network_project_id
 }
 
 resource "google_compute_router" "nat" {
   name    = "redpanda-router${local.postfix}"
-  network = google_compute_network.redpanda.name
+  network = data.google_compute_network.redpanda.name
   region  = var.region
   depends_on = [
-    google_compute_network.redpanda
+    data.google_compute_network.redpanda
   ]
   project = var.network_project_id
 }
@@ -81,7 +102,7 @@ data "google_project" "service_project" {
 }
 
 data "google_iam_policy" "subnetwork_iam" {
-  count = local.is_shared_vpc ? 1 : 0
+  count = local.create_vpc && local.is_shared_vpc ? 1 : 0
   binding {
     role = "roles/compute.networkUser"
     members = [
@@ -121,9 +142,9 @@ resource "google_project_iam_binding" "gke_firewall_iam" {
 }
 
 resource "google_compute_subnetwork_iam_policy" "policy" {
-  count       = local.is_shared_vpc ? 1 : 0
-  project     = google_compute_subnetwork.redpanda.project
-  region      = google_compute_subnetwork.redpanda.region
-  subnetwork  = google_compute_subnetwork.redpanda.name
+  count       = local.create_vpc && local.is_shared_vpc ? 1 : 0
+  project     = data.google_compute_subnetwork.redpanda.project
+  region      = data.google_compute_subnetwork.redpanda.region
+  subnetwork  = data.google_compute_subnetwork.redpanda.name
   policy_data = data.google_iam_policy.subnetwork_iam[0].policy_data
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -37,15 +37,15 @@ resource "google_compute_subnetwork" "redpanda" {
   name                     = "redpanda-subnetwork${local.postfix}"
   network                  = data.google_compute_network.redpanda.id
   region                   = var.region
-  ip_cidr_range            = "10.0.0.0/24"
+  ip_cidr_range            = var.subnetwork_ip_cidr_range
   private_ip_google_access = true
   stack_type               = "IPV4_ONLY"
   secondary_ip_range {
-    ip_cidr_range = "10.0.8.0/21"
+    ip_cidr_range = var.subnetwork_pods_secondary_ip_range
     range_name    = var.secondary_ipv4_range_pods_name
   }
   secondary_ip_range {
-    ip_cidr_range = "10.0.1.0/24"
+    ip_cidr_range = var.subnetwork_services_secondary_ip_range
     range_name    = var.secondary_ipv4_range_services_name
   }
   depends_on = [

--- a/vpc_psc.tf
+++ b/vpc_psc.tf
@@ -12,7 +12,7 @@ resource "google_compute_subnetwork" "psc_nat" {
 }
 
 data "google_iam_policy" "nat_subnet_iam" {
-  count = local.using_shared_vpc && var.enable_private_link ? 1 : 0
+  count = local.is_shared_vpc && var.enable_private_link ? 1 : 0
   binding {
     role = "roles/compute.networkUser"
     members = [
@@ -24,7 +24,7 @@ data "google_iam_policy" "nat_subnet_iam" {
 
 # Required so the service attachment can use the PSC NAT subnet, which exists in the HOST project.
 resource "google_compute_subnetwork_iam_policy" "nat_subnet_policy" {
-  count       = local.using_shared_vpc && var.enable_private_link ? 1 : 0
+  count       = local.is_shared_vpc && var.enable_private_link ? 1 : 0
   project     = google_compute_subnetwork.psc_nat[0].project
   region      = google_compute_subnetwork.psc_nat[0].region
   subnetwork  = google_compute_subnetwork.psc_nat[0].name

--- a/vpc_psc.tf
+++ b/vpc_psc.tf
@@ -7,7 +7,7 @@ resource "google_compute_subnetwork" "psc_nat" {
   region        = var.region
   ip_cidr_range = var.psc_nat_subnet_ipv4_range
   purpose       = "PRIVATE_SERVICE_CONNECT"
-  network       = google_compute_network.redpanda.id
+  network       = data.google_compute_network.redpanda.id
   project       = var.network_project_id
 }
 


### PR DESCRIPTION
1. Renamed `using_shared_vpc` to `is_shared_vpc`. I think this is more readable.
2. Added vars for `vpc_name` and `subnet_name`. If passing in a pre-existing VPC, then subnet is also required.