### PR TITLE
Make psc subnet creation optional

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -27,7 +27,7 @@ output "gke_service_account_email" {
 }
 
 output "psc_nat_subnet_name" {
-  value = var.enable_private_link ? google_compute_subnetwork.psc_nat[0].name : ""
+  value = var.enable_private_link ? data.google_compute_subnetwork.psc_nat.name : ""
 }
 
 output "redpanda_cluster_service_account_email" {

--- a/variables.tf
+++ b/variables.tf
@@ -150,6 +150,7 @@ variable "subnet_name" {
   The name of the subnet if created outside of this module. If vpc_name is provided, this value is required.
   HELP
   validation {
+# We expect that when vpc_name and subnet_name are both nil or both not nil, this should pass. Otherwise, this should fail. 
     condition     = (var.vpc_name == "") == (var.subnet_name == "")
     error_message = "If vpc_name is provided, subnet_name is required"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -111,6 +111,22 @@ variable "attach_shared_vpc" {
   HELP
 }
 
+variable "psc_subnet_name" {
+  type        = string
+  default     = ""
+  description = <<-HELP
+    The name of the PSC subnet if created outside of this module. If vpc_name is provided and private link is enabled,
+    this value is required.
+    HELP
+  validation {
+    #    If private link is not enabled, psc_subnet_name should not be provided
+    #    If private link is enabled and vpc_name is provided, psc_subnet_name is required
+    #    If private link is enabled and vpc_name is not provided, psc_subnet_name should not be provided
+    condition     = (!var.enable_private_link && var.psc_subnet_name == "") || (var.enable_private_link && (var.vpc_name == "") == (var.psc_subnet_name == ""))
+    error_message = "If private link is enabled and vpc_name is provided, psc_subnet_name is required"
+  }
+}
+
 variable "psc_nat_subnet_ipv4_range" {
   type        = string
   default     = "10.0.2.0/29"
@@ -134,7 +150,7 @@ variable "subnet_name" {
   The name of the subnet if created outside of this module. If vpc_name is provided, this value is required.
   HELP
   validation {
-    condition     = var.vpc_name != "" && var.subnet_name != ""
+    condition     = (var.vpc_name == "") == (var.subnet_name == "")
     error_message = "If vpc_name is provided, subnet_name is required"
   }
 }

--- a/vpc_psc.tf
+++ b/vpc_psc.tf
@@ -1,14 +1,23 @@
+locals {
+  create_psc_subnetwork = local.create_vpc && var.enable_private_link
+}
 
 # This resource isn't required for all BYOVPC deployments.
 # It's only here to make testing Private Link on BYOVPC clusters a little bit easier.
 resource "google_compute_subnetwork" "psc_nat" {
-  count         = var.enable_private_link ? 1 : 0
+  count         = local.create_psc_subnetwork ? 1 : 0
   name          = "redpanda-psc-nat-subnetwork${local.postfix}"
   region        = var.region
   ip_cidr_range = var.psc_nat_subnet_ipv4_range
   purpose       = "PRIVATE_SERVICE_CONNECT"
   network       = data.google_compute_network.redpanda.id
   project       = var.network_project_id
+}
+
+data "google_compute_subnetwork" "psc_nat" {
+  name    = local.create_psc_subnetwork ? google_compute_subnetwork.psc_nat[0].name : var.psc_subnet_name
+  region  = var.region
+  project = var.network_project_id
 }
 
 data "google_iam_policy" "nat_subnet_iam" {
@@ -25,8 +34,8 @@ data "google_iam_policy" "nat_subnet_iam" {
 # Required so the service attachment can use the PSC NAT subnet, which exists in the HOST project.
 resource "google_compute_subnetwork_iam_policy" "nat_subnet_policy" {
   count       = local.is_shared_vpc && var.enable_private_link ? 1 : 0
-  project     = google_compute_subnetwork.psc_nat[0].project
-  region      = google_compute_subnetwork.psc_nat[0].region
-  subnetwork  = google_compute_subnetwork.psc_nat[0].name
+  project     = data.google_compute_subnetwork.psc_nat.project
+  region      = data.google_compute_subnetwork.psc_nat.region
+  subnetwork  = data.google_compute_subnetwork.psc_nat.name
   policy_data = data.google_iam_policy.nat_subnet_iam[0].policy_data
 }


### PR DESCRIPTION
If variable `enable_private_link` is true the caller can choose to provide a pre-existing subnet name in which case creation of the subnet will be skipped.