### PR TITLE
fix: cross variable validation error

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -34,7 +34,7 @@ output "gke_service_account_email" {
 }
 
 output "psc_nat_subnet_name" {
-  value       = var.enable_private_link ? data.google_compute_subnetwork.psc_nat.name : ""
+  value       = var.enable_private_link ? data.google_compute_subnetwork.psc_nat[0].name : ""
   description = "The name of the PSC NAT subnet, if private link is enabled."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -118,12 +118,22 @@ variable "psc_subnet_name" {
     The name of the PSC subnet if created outside of this module. If vpc_name is provided and private link is enabled,
     this value is required.
     HELP
-  validation {
-    #    If private link is not enabled, psc_subnet_name should not be provided
-    #    If private link is enabled and vpc_name is provided, psc_subnet_name is required
-    #    If private link is enabled and vpc_name is not provided, psc_subnet_name should not be provided
-    condition     = (!var.enable_private_link && var.psc_subnet_name == "") || (var.enable_private_link && (var.vpc_name == "") == (var.psc_subnet_name == ""))
-    error_message = "If private link is enabled and vpc_name is provided, psc_subnet_name is required"
+}
+
+resource "terraform_data" "validation" {
+  input = "validation-only"
+
+  #    If private link is not enabled, psc_subnet_name should not be provided
+  #    If private link is enabled and vpc_name is provided, psc_subnet_name is required
+  #    If private link is enabled and vpc_name is not provided, psc_subnet_name should not be provided
+  lifecycle {
+    precondition {
+      condition = (
+      (!var.enable_private_link && var.psc_subnet_name == "") ||
+      (var.enable_private_link && (var.vpc_name == "") == (var.psc_subnet_name == ""))
+      )
+      error_message = "Configuration error: If private link is enabled and vpc_name is provided, psc_subnet_name is required. If private link is not enabled, psc_subnet_name should not be provided."
+    }
   }
 }
 
@@ -149,10 +159,16 @@ variable "subnet_name" {
   description = <<-HELP
   The name of the subnet if created outside of this module. If vpc_name is provided, this value is required.
   HELP
-  validation {
-# We expect that when vpc_name and subnet_name are both nil or both not nil, this should pass. Otherwise, this should fail. 
-    condition     = (var.vpc_name == "") == (var.subnet_name == "")
-    error_message = "If vpc_name is provided, subnet_name is required"
+}
+
+resource "terraform_data" "subnet_validation" {
+  input = "validation-only"
+  # We expect that when vpc_name and subnet_name are both nil or both not nil, this should pass. Otherwise, this should fail.
+  lifecycle {
+    precondition {
+      condition     = (var.vpc_name == "") == (var.subnet_name == "")
+      error_message = "If vpc_name is provided, subnet_name is required. Both must be either specified or unspecified."
+    }
   }
 }
 

--- a/vpc_psc.tf
+++ b/vpc_psc.tf
@@ -15,6 +15,7 @@ resource "google_compute_subnetwork" "psc_nat" {
 }
 
 data "google_compute_subnetwork" "psc_nat" {
+  count = local.create_psc_subnetwork ? 1 : 0
   name    = local.create_psc_subnetwork ? google_compute_subnetwork.psc_nat[0].name : var.psc_subnet_name
   region  = var.region
   project = var.network_project_id
@@ -34,8 +35,8 @@ data "google_iam_policy" "nat_subnet_iam" {
 # Required so the service attachment can use the PSC NAT subnet, which exists in the HOST project.
 resource "google_compute_subnetwork_iam_policy" "nat_subnet_policy" {
   count       = local.is_shared_vpc && var.enable_private_link ? 1 : 0
-  project     = data.google_compute_subnetwork.psc_nat.project
-  region      = data.google_compute_subnetwork.psc_nat.region
-  subnetwork  = data.google_compute_subnetwork.psc_nat.name
+  project     = data.google_compute_subnetwork.psc_nat[0].project
+  region      = data.google_compute_subnetwork.psc_nat[0].region
+  subnetwork  = data.google_compute_subnetwork.psc_nat[0].name
   policy_data = data.google_iam_policy.nat_subnet_iam[0].policy_data
 }


### PR DESCRIPTION
Terraform variables cannot reference other terraform variables when doing validation. terraform_data should allow a do nothing end run around this issue because it is a resource.

There was also a minor issue with the conditionality of one of the data values for PSC. 