### PR TITLE
fix: grant agent compute.{region,global}Operations.list

### DIFF
--- a/iam_agent.tf
+++ b/iam_agent.tf
@@ -2,9 +2,10 @@ locals {
   service_project_core_agent_permissions = [
     "compute.firewalls.get",
     "compute.globalOperations.get",
-    "compute.disks.get",       # required for applying custom labels via go code
-    "compute.disks.list",      # required for applying custom labels via go code
-    "compute.disks.setLabels", # required for applying custom labels via go code
+    "compute.globalOperations.list", # required for detection/details of quota/stockout errors and incident investigation
+    "compute.disks.get",             # required for applying custom labels via go code
+    "compute.disks.list",            # required for applying custom labels via go code
+    "compute.disks.setLabels",       # required for applying custom labels via go code
     "compute.instanceGroupManagers.get",
     "compute.instanceGroupManagers.delete",
     "compute.instanceGroupManagers.update",
@@ -17,6 +18,7 @@ locals {
     "compute.networks.getRegionEffectiveFirewalls",
     "compute.networks.getEffectiveFirewalls",
     "compute.projects.get",
+    "compute.regionOperations.list", # required for detection/details of quota/stockout errors and incident investigation
     "compute.subnetworks.get",
     "compute.subnetworks.getIamPolicy", # required for validation/drift-detection
     "compute.zoneOperations.get",


### PR DESCRIPTION
## What

Adds two read-only GCP IAM permissions to `service_project_core_agent_permissions` in the Redpanda agent role:

- `compute.regionOperations.list`
- `compute.globalOperations.list`

## Why

During cloudv2 INC-1898 (CIAINFRA-1496), on-call/break-glass could not enumerate GCP compute operations during incident investigation:

```
$ gcloud compute operations list --filter <cluster-id> --regions us-central1
ERROR: (gcloud.compute.operations.list) Some requests did not succeed:
 - Required 'compute.regionOperations.list' permission for 'projects/...'
```

The agent role already grants `compute.zoneOperations.list` (same quota/stockout-detection use case) and `*Operations.get`, but was missing the `regionOperations.list` / `globalOperations.list` needed to *list* operations.

Both permissions are read-only/observational (part of `roles/compute.viewer`) and were verified valid + custom-role-supported via `gcloud iam list-testable-permissions`. Added to the core (always-on) block since incident investigation is not private-link specific.

## Related

Mirrors the equivalent fix in cloudv2: redpanda-data/cloudv2#26769 (`pkg/provisioners/gcp/terraform/agent` + `tools/byo_resources`).

## Customer impact

BYOVPC customers must **re-apply** this module to pick up the expanded role. Read-only, strictly additive — no functional regression if not yet applied; the gap only affects incident response.

CIAINFRA-1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)