### PR TITLE
fix: grant agent compute.instanceGroupManagers.list

### DIFF
--- a/iam_agent.tf
+++ b/iam_agent.tf
@@ -7,6 +7,7 @@ locals {
     "compute.disks.list",            # required for applying custom labels via go code
     "compute.disks.setLabels",       # required for applying custom labels via go code
     "compute.instanceGroupManagers.get",
+    "compute.instanceGroupManagers.list",
     "compute.instanceGroupManagers.delete",
     "compute.instanceGroupManagers.update",
     "compute.instanceGroups.delete",

--- a/iam_test_user.tf
+++ b/iam_test_user.tf
@@ -42,6 +42,7 @@ resource "google_project_iam_custom_role" "test_user_role" {
     "compute.instanceTemplates.delete",
     "compute.instanceGroups.create",
     "compute.instanceGroupManagers.get",
+    "compute.instanceGroupManagers.list",
     "iam.serviceAccounts.actAs",
     "compute.instanceGroupManagers.delete",
     "compute.instanceGroups.delete",


### PR DESCRIPTION
## Summary

This change is triggered by the Google Terraform provider v7 upgrade. Starting in `v7`, the provider
reads `google_container_node_pool` via the instance-group-manager list API, which requires the
`compute.instanceGroupManagers.list` permission that the BYOVPC roles do not currently grant. Without
it, `terraform plan` during cluster reconciliation (or `rpk byoc apply`) fails with:

```
Required 'compute.instanceGroupManagers.list' permission for 'projects/<project>'
```

The read-only `compute.instanceGroupManagers.list` permission is added to:
- `iam_agent.tf` — `service_project_core_agent_permissions` (the redpanda agent role that hits the
  failure at runtime)
- `iam_test_user.tf` — `test_user_role` (the minimum role for the user creating the cluster)

alongside the existing `instanceGroupManagers.get`/`delete`/`update` grants. The permission is part of
`roles/compute.viewer` and is custom-role-supported.

This mirrors the equivalent cloudv2 change (`pkg/provisioners/gcp/terraform/agent` +
`tools/byo_resources`), PR redpanda-data/cloudv2#27574, which is itself split out of the v7 provider
upgrade (redpanda-data/cloudv2#27536).

**BYOVPC customers must re-apply this module to pick up the change.**

## Refs

- Mirrors cloudv2 redpanda-data/cloudv2#27574 (split from the v7 upgrade redpanda-data/cloudv2#27536)
- https://redpandadata.atlassian.net/browse/CIAINFRA-2225
