### PR TITLE
fix: grant agent compute.instanceGroupManagers.list

### DIFF
--- a/iam_agent.tf
+++ b/iam_agent.tf
@@ -7,6 +7,7 @@ locals {
     "compute.disks.list",            # required for applying custom labels via go code
     "compute.disks.setLabels",       # required for applying custom labels via go code
     "compute.instanceGroupManagers.get",
+    "compute.instanceGroupManagers.list",
     "compute.instanceGroupManagers.delete",
     "compute.instanceGroupManagers.update",
     "compute.instanceGroups.delete",

--- a/iam_test_user.tf
+++ b/iam_test_user.tf
@@ -42,6 +42,7 @@ resource "google_project_iam_custom_role" "test_user_role" {
     "compute.instanceTemplates.delete",
     "compute.instanceGroups.create",
     "compute.instanceGroupManagers.get",
+    "compute.instanceGroupManagers.list",
     "iam.serviceAccounts.actAs",
     "compute.instanceGroupManagers.delete",
     "compute.instanceGroups.delete",


### PR DESCRIPTION
## Summary

The Google Terraform provider reads `google_container_node_pool` by **listing** the node pool's instance group managers — IGM caching introduced in provider PR [#25784](https://github.com/hashicorp/terraform-provider-google/pull/25784), which replaced the per-IGM `get` calls with a single `list` call. That `list` call needs the `compute.instanceGroupManagers.list` permission, which the BYOVPC roles do not currently grant. Without it, the agent's `terraform plan` during cluster reconciliation (or `rpk byoc apply`) fails with:

```
Error: Error when reading or editing InstanceGroupManagers for node pool "<pool>":
googleapi: Error 403: Required 'compute.instanceGroupManagers.list' permission for 'projects/<project>'
```

Version range: the node pools are managed with the `google-beta` provider, where this shipped in the v7 line - It was promoted to GA in the `google` provider in **v7.17.0** (Jan 2026, #25784) and is still in effect at the current **v7.38.0**.

Adds the read-only `compute.instanceGroupManagers.list` permission to:
- `iam_agent.tf` — `service_project_core_agent_permissions` (the redpanda agent role that performs the
  read at runtime)
- `iam_test_user.tf` — `test_user_role` (the minimum role for the user creating the cluster)

alongside the existing `instanceGroupManagers.get`/`delete`/`update` grants. The permission is part of
`roles/compute.viewer` and is custom-role-supported.

This mirrors the equivalent change in cloudv2 (`pkg/provisioners/gcp/terraform/agent` + `tools/byo_resources`).

**BYOVPC customers must re-apply this module to pick up the change.**
