### PR TITLE
Adds RPSQL options for BYOVPC

### DIFF
--- a/iam_rpsql.tf
+++ b/iam_rpsql.tf
@@ -18,6 +18,19 @@ resource "google_project_iam_custom_role" "redpanda_sql_api_secrets_access" {
   ]
 }
 
+resource "google_project_iam_member" "redpanda_sql_api_secrets_access" {
+  count   = var.enable_redpanda_sql ? 1 : 0
+  project = var.service_project_id
+  role    = google_project_iam_custom_role.redpanda_sql_api_secrets_access[0].id
+  member  = "serviceAccount:${google_service_account.redpanda_sql_api[0].email}"
+
+  condition {
+    title       = "RPSqlSecretsRestriction"
+    description = "Restrict access to Redpanda SQL Secret Manager prefix"
+    expression  = "resource.name.startsWith('projects/_/secrets/${local.rpsql_secret_manager_prefix}')"
+  }
+}
+
 resource "google_service_account_iam_member" "redpanda_sql_api_workload_identity" {
   count              = var.enable_redpanda_sql ? 1 : 0
   service_account_id = google_service_account.redpanda_sql_api[0].name
@@ -57,7 +70,7 @@ resource "google_project_iam_member" "redpanda_sql_cluster_storage" {
   condition {
     title       = "RPSqlPathRestriction"
     description = "Restrict access to oxla prefix only"
-    expression  = "resource.name.startsWith('projects/${var.service_project_id}/buckets/${google_storage_bucket.redpanda_sql[0].name}/objects/oxla')"
+    expression  = "resource.name.startsWith('projects/_/buckets/${google_storage_bucket.redpanda_sql[0].name}/objects/oxla')"
   }
 
   depends_on = [google_storage_bucket.redpanda_sql]
@@ -83,7 +96,7 @@ resource "google_project_iam_member" "redpanda_sql_cluster_storage_list" {
   condition {
     title       = "RPSqlListRestriction"
     description = "Restrict access to oxla prefix only"
-    expression  = "resource.name.startsWith('projects/${var.service_project_id}/buckets/${google_storage_bucket.redpanda_sql[0].name}')"
+    expression  = "resource.name.startsWith('projects/_/buckets/${google_storage_bucket.redpanda_sql[0].name}')"
   }
 
   depends_on = [google_storage_bucket.redpanda_sql]

--- a/iam_rpsql.tf
+++ b/iam_rpsql.tf
@@ -1,0 +1,97 @@
+# Redpanda SQL API
+resource "google_service_account" "redpanda_sql_api" {
+  count                        = var.enable_redpanda_sql ? 1 : 0
+  account_id                   = "redpanda-sql-api${local.postfix}"
+  display_name                 = "Redpanda SQL API Service Account"
+  project                      = var.service_project_id
+  create_ignore_already_exists = true
+}
+
+resource "google_project_iam_custom_role" "redpanda_sql_api_secrets_access" {
+  count   = var.enable_redpanda_sql ? 1 : 0
+  project = var.service_project_id
+  role_id = replace("redpanda_sql_api_role${local.postfix}", "-", "_")
+  title   = "Redpanda SQL API Secrets Access Role"
+  permissions = [
+    "secretmanager.secrets.get",
+    "secretmanager.versions.access",
+  ]
+}
+
+resource "google_service_account_iam_member" "redpanda_sql_api_workload_identity" {
+  count              = var.enable_redpanda_sql ? 1 : 0
+  service_account_id = google_service_account.redpanda_sql_api[0].name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.service_project_id}.svc.id.goog[redpanda-oxla/${google_service_account.redpanda_sql_api[0].account_id}]"
+}
+
+
+# Redpanda SQL
+resource "google_service_account" "redpanda_sql" {
+  count                        = var.enable_redpanda_sql ? 1 : 0
+  account_id                   = "redpanda-sql${local.postfix}"
+  display_name                 = "Redpanda SQL Service Account"
+  project                      = var.service_project_id
+  create_ignore_already_exists = true
+}
+
+# This role gives editor permissions to the RPSql storage bucket. This role can be scoped to the name of the bucket.
+resource "google_project_iam_custom_role" "redpanda_sql_cluster_storage" {
+  count   = var.enable_redpanda_sql ? 1 : 0
+  project = var.service_project_id
+  role_id = replace("redpanda_sql_storage${local.postfix}", "-", "_")
+  title   = "Redpanda SQL Cluster Storage Role"
+  permissions = [
+    "storage.objects.create",
+    "storage.objects.delete",
+    "storage.objects.get",
+  ]
+}
+
+resource "google_project_iam_member" "redpanda_sql_cluster_storage" {
+  count   = var.enable_redpanda_sql ? 1 : 0
+  project = var.service_project_id
+  role    = google_project_iam_custom_role.redpanda_sql_cluster_storage[0].id
+  member  = "serviceAccount:${google_service_account.redpanda_sql[0].email}"
+
+  condition {
+    title       = "RPSqlPathRestriction"
+    description = "Restrict access to oxla prefix only"
+    expression  = "resource.name.startsWith('projects/${var.service_project_id}/buckets/${google_storage_bucket.redpanda_sql[0].name}/objects/oxla')"
+  }
+
+  depends_on = [google_storage_bucket.redpanda_sql]
+}
+
+# storage.objects.list permission is granted at the bucket level and cannot be name scoped.
+resource "google_project_iam_custom_role" "redpanda_sql_cluster_storage_list" {
+  count   = var.enable_redpanda_sql ? 1 : 0
+  project = var.service_project_id
+  role_id = replace("redpanda_sql_storage_list${local.postfix}", "-", "_")
+  title   = "Redpanda SQL Cluster Storage List Role"
+  permissions = [
+    "storage.objects.list",
+  ]
+}
+
+resource "google_project_iam_member" "redpanda_sql_cluster_storage_list" {
+  count   = var.enable_redpanda_sql ? 1 : 0
+  project = var.service_project_id
+  role    = google_project_iam_custom_role.redpanda_sql_cluster_storage_list[0].id
+  member  = "serviceAccount:${google_service_account.redpanda_sql[0].email}"
+
+  condition {
+    title       = "RPSqlListRestriction"
+    description = "Restrict access to oxla prefix only"
+    expression  = "resource.name.startsWith('projects/${var.service_project_id}/buckets/${google_storage_bucket.redpanda_sql[0].name}')"
+  }
+
+  depends_on = [google_storage_bucket.redpanda_sql]
+}
+
+resource "google_service_account_iam_member" "redpanda_oxla_cluster_workload_identity" {
+  count              = var.enable_redpanda_sql ? 1 : 0
+  service_account_id = google_service_account.redpanda_sql[0].name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.service_project_id}.svc.id.goog[redpanda-oxla/${google_service_account.redpanda_sql[0].account_id}]"
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,5 @@
 locals {
-  is_shared_vpc = (var.service_project_id != var.network_project_id)
-  postfix       = var.unique_identifier != "" ? "-${var.unique_identifier}" : ""
+  is_shared_vpc              = (var.service_project_id != var.network_project_id)
+  postfix                    = var.unique_identifier != "" ? "-${var.unique_identifier}" : ""
+  rpsql_secret_manager_prefix = "redpanda-sql${local.postfix}-"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -92,3 +92,18 @@ output "test_user_account" {
   value       = var.create_test_user ? google_service_account.test_user_account[0].account_id : ""
   description = "The email address of the test user account, if created."
 }
+
+output "redpanda_sql_api_service_account_email" {
+  value       = var.enable_redpanda_sql ? google_service_account.redpanda_sql_api[0].email : ""
+  description = "The Redpanda SQL API Service Account email"
+}
+
+output "redpanda_sql_service_account_email" {
+  value       = var.enable_redpanda_sql ? google_service_account.redpanda_sql[0].email : ""
+  description = "The Redpanda SQL Service Account email"
+}
+
+output "redpanda_sql_storage_bucket_name" {
+  value       = var.enable_redpanda_sql ? google_storage_bucket.redpanda_sql[0].name : ""
+  description = "The Redpanda SQL storage bucket name"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -107,3 +107,8 @@ output "redpanda_sql_storage_bucket_name" {
   value       = var.enable_redpanda_sql ? google_storage_bucket.redpanda_sql[0].name : ""
   description = "The Redpanda SQL storage bucket name"
 }
+
+output "redpanda_sql_secret_manager_prefix" {
+  value       = var.enable_redpanda_sql ? local.rpsql_secret_manager_prefix : ""
+  description = "The Secret Manager prefix for Redpanda SQL catalog credentials."
+}

--- a/rpsql.tf
+++ b/rpsql.tf
@@ -1,0 +1,15 @@
+
+resource "google_storage_bucket" "redpanda_sql" {
+  count                       = var.enable_redpanda_sql ? 1 : 0
+  name                        = "redpanda-sql-storage${local.postfix}"
+  location                    = var.region
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+  force_destroy               = var.force_destroy_sql_storage_bucket
+  versioning {
+    enabled = false
+  }
+  project = var.service_project_id
+}
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,22 @@ variable "enable_private_link" {
   HELP
 }
 
+variable "enable_redpanda_sql" {
+  type        = bool
+  default     = false
+  description = <<-HELP
+  When true, Redpanda SQL resources will be created
+  HELP
+}
+
+variable "force_destroy_sql_storage_bucket" {
+  type        = bool
+  default     = false
+  description = <<-HELP
+  When deleting the Redpanda SQL bucket, this boolean option will delete all contained objects.
+  HELP
+}
+
 variable "force_destroy_mgmt_bucket" {
   type        = bool
   default     = false


### PR DESCRIPTION
Adds RPSql for BYOVPC. Resources are gated on an `enable_redpanda_sql` variable. Output `redpanda_sql_secret_manager_prefix` takes a "no footgun" approach that customers provide to the API but don't have to worry about providing since migration of existing secrets would be difficult.