### PR TITLE
Add BigLake IAM grants for GCP BYOVPC

### DIFF
--- a/api_enablement.tf
+++ b/api_enablement.tf
@@ -67,3 +67,18 @@ resource "google_project_service" "network_project_container_api" {
   disable_on_destroy         = false
   project                    = var.network_project_id
 }
+
+resource "google_project_service" "biglake_api" {
+  service                    = "biglake.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+  project                    = var.service_project_id
+}
+
+# BigLake is built on BigQuery; the BigQuery API must also be enabled.
+resource "google_project_service" "bigquery_api" {
+  service                    = "bigquery.googleapis.com"
+  disable_dependent_services = false
+  disable_on_destroy         = false
+  project                    = var.service_project_id
+}

--- a/iam_cluster.tf
+++ b/iam_cluster.tf
@@ -16,3 +16,23 @@ resource "google_service_account_iam_member" "redpanda_cluster_service_account_b
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.service_project_id}.svc.id.goog[redpanda/rp-${google_service_account.redpanda_cluster.account_id}]"
 }
+
+# BigLake (broker-native Iceberg via BigLake REST catalog) grants for the Redpanda cluster SA.
+# Mirrors the grants Redpanda applies for Redpanda-managed clusters.
+# The biglake/bigquery APIs are enabled unconditionally in api_enablement.tf. Storage access
+# to the BigLake warehouse bucket is already covered above (redpanda_cluster_cloud_storage_admin, bucket-scoped) — the
+# warehouse is this module's tiered-storage bucket, not a separate one.
+
+# BigLake Editor — access the Iceberg REST catalog via the BigLake API.
+resource "google_project_iam_member" "redpanda_cluster_biglake_editor" {
+  project = var.service_project_id
+  role    = "roles/biglake.editor"
+  member  = "serviceAccount:${google_service_account.redpanda_cluster.email}"
+}
+
+# Service Usage Consumer — required by BigLake to interact with GCP services.
+resource "google_project_iam_member" "redpanda_cluster_service_usage_consumer" {
+  project = var.service_project_id
+  role    = "roles/serviceusage.serviceUsageConsumer"
+  member  = "serviceAccount:${google_service_account.redpanda_cluster.email}"
+}

--- a/iam_rpsql.tf
+++ b/iam_rpsql.tf
@@ -136,17 +136,9 @@ resource "google_project_iam_member" "redpanda_sql_iceberg_storage" {
 }
 
 # BigLake (Iceberg REST catalog on GCP) grants for the Redpanda SQL cluster SA.
-# Mirrors the grants Redpanda applies for Redpanda-managed clusters; for BYOVPC
-# the customer's own module (this one) is responsible for them.
-
-# Storage Admin — access to the underlying BigLake storage bucket, which may differ
-# from the tiered-storage bucket, so this is project-wide rather than bucket-scoped.
-resource "google_project_iam_member" "redpanda_sql_storage_admin" {
-  count   = var.enable_redpanda_sql ? 1 : 0
-  project = var.service_project_id
-  role    = "roles/storage.objectAdmin"
-  member  = "serviceAccount:${google_service_account.redpanda_sql[0].email}"
-}
+# Mirrors the grants Redpanda applies for Redpanda-managed clusters
+# BigLake warehouse bucket is already covered above (redpanda_sql_iceberg_storage,
+# scoped to the redpanda_cloud_storage bucket) — no separate warehouse bucket is in play.
 
 # BigLake Editor — access the Iceberg REST catalog via the BigLake API.
 resource "google_project_iam_member" "redpanda_sql_biglake_editor" {

--- a/iam_rpsql.tf
+++ b/iam_rpsql.tf
@@ -135,3 +135,32 @@ resource "google_project_iam_member" "redpanda_sql_iceberg_storage" {
   }
 }
 
+# BigLake (Iceberg REST catalog on GCP) grants for the Redpanda SQL cluster SA.
+# Mirrors the grants Redpanda applies for Redpanda-managed clusters; for BYOVPC
+# the customer's own module (this one) is responsible for them.
+
+# Storage Admin — access to the underlying BigLake storage bucket, which may differ
+# from the tiered-storage bucket, so this is project-wide rather than bucket-scoped.
+resource "google_project_iam_member" "redpanda_sql_storage_admin" {
+  count   = var.enable_redpanda_sql ? 1 : 0
+  project = var.service_project_id
+  role    = "roles/storage.objectAdmin"
+  member  = "serviceAccount:${google_service_account.redpanda_sql[0].email}"
+}
+
+# BigLake Editor — access the Iceberg REST catalog via the BigLake API.
+resource "google_project_iam_member" "redpanda_sql_biglake_editor" {
+  count   = var.enable_redpanda_sql ? 1 : 0
+  project = var.service_project_id
+  role    = "roles/biglake.editor"
+  member  = "serviceAccount:${google_service_account.redpanda_sql[0].email}"
+}
+
+# Service Usage Consumer — required by BigLake to interact with GCP services.
+resource "google_project_iam_member" "redpanda_sql_service_usage_consumer" {
+  count   = var.enable_redpanda_sql ? 1 : 0
+  project = var.service_project_id
+  role    = "roles/serviceusage.serviceUsageConsumer"
+  member  = "serviceAccount:${google_service_account.redpanda_sql[0].email}"
+}
+


### PR DESCRIPTION
## Summary
- Enables `biglake.googleapis.com` and `bigquery.googleapis.com`, and grants `roles/biglake.editor` + `roles/serviceusage.serviceUsageConsumer` on the `redpanda_cluster` SA (broker-native Iceberg) and the `redpanda_sql` SA (RPSql/Oxla), mirroring the grants Redpanda applies for Redpanda-managed clusters.
- No new project-wide storage grants — the BigLake warehouse is this module's own tiered-storage bucket, which already has scoped `storage.objectAdmin` via the existing bucket-level bindings.

## Test plan
- [x] Validated using RP Cloud provisioning certification test suite