### PR TITLE
fix: operator SA uses hardcoded account id

### DIFF
--- a/iam_operator.tf
+++ b/iam_operator.tf
@@ -8,7 +8,7 @@ resource "google_service_account" "redpanda_operator" {
 resource "google_service_account_iam_member" "redpanda_operator_service_account_binding" {
   service_account_id = google_service_account.redpanda_operator.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "serviceAccount:${var.service_project_id}.svc.id.goog[redpanda-system/redpanda-operator-sa]"
+  member             = "serviceAccount:${var.service_project_id}.svc.id.goog[redpanda-system/${google_service_account.redpanda_operator.account_id}]"
 }
 
 resource "google_project_iam_custom_role" "redpanda_operator_custom_role" {

--- a/iam_rpsql.tf
+++ b/iam_rpsql.tf
@@ -27,7 +27,7 @@ resource "google_project_iam_member" "redpanda_sql_api_secrets_access" {
   condition {
     title       = "RPSqlSecretsRestriction"
     description = "Restrict access to Redpanda SQL Secret Manager prefix"
-    expression  = "resource.name.startsWith('projects/_/secrets/${local.rpsql_secret_manager_prefix}')"
+    expression  = "resource.name.startsWith('projects/${var.service_project_id}/secrets/redpanda-')"
   }
 }
 


### PR DESCRIPTION
The SA account id is hardocoded and should use the service account ID instead. This value is passed to Cloud to create the Kubernetes SA. The hardcoded value would result in the binding never being established.

Additionally fix for the secret prefix being too specific and un-scoped to project..